### PR TITLE
Set trust_ratio to 1 if weight_norm or adam_norm is 0.

### DIFF
--- a/pytorch_lamb/lamb.py
+++ b/pytorch_lamb/lamb.py
@@ -110,7 +110,10 @@ class Lamb(Optimizer):
                     adam_step.add_(group['weight_decay'], p.data)
 
                 adam_norm = adam_step.pow(2).sum().sqrt()
-                trust_ratio = weight_norm / adam_norm
+                if weight_norm == 0 or adam_norm == 0:
+                    trust_ratio = 1
+                else:
+                    trust_ratio = weight_norm / adam_norm
                 state['weight_norm'] = weight_norm
                 state['adam_norm'] = adam_norm
                 state['trust_ratio'] = trust_ratio


### PR DESCRIPTION
This fixes issues with learning weights for layers that start out as zeroes (for instance bias in normalization layers).  In the current version if a layer starts out as all zeroes the weights will never change.

This was done earlier in the implementation in this repo also, but is not present in the current version. According to the TensorFlow implementation (see https://github.com/ymcui/LAMB_Optimizer_TF/blob/a804c2f2995cda9a4f6b804ab445e19fc4a1036f/optimization.py#L264) setting the trust_ratio to 1 is how the paper authors do also in case the numerator or denominator is zero.